### PR TITLE
Add to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,5 +140,6 @@ dmypy.json
 *.svg
 *.mtx
 *.txt
+/notebooks/sample_notebook
 
 .idea


### PR DESCRIPTION
This adds the sample notebook locally but also adds it to the gitignore so we don't upload it as it isn't interesting for the end user. 